### PR TITLE
Can't set slot error bugfix

### DIFF
--- a/src/pytest/test_runner.py
+++ b/src/pytest/test_runner.py
@@ -136,6 +136,10 @@ def run(test_dir, exclude_list=None, pattern='test_*.py', capture_stdout=True):
                             # Invoke test method
                             test_method(**kwargs)
 
+                            # reset any patched attributes
+                            if "mocker" in kwargs:
+                                kwargs["mocker"].stop()
+
                             result['result'] = '.'
                     except:   # noqa: E722
                         errors += 1
@@ -144,15 +148,16 @@ def run(test_dir, exclude_list=None, pattern='test_*.py', capture_stdout=True):
                         result['exception_message'] = sys.exc_info()[1]
                     finally:
                         result['out'] = out
-                        # Unload modules loaded by the test
-                        modules_loaded_by_test = [m for m in sys.modules if m not in loaded_modules]
-                        for module_to_unload in modules_loaded_by_test:
-                            sys.modules.pop(module_to_unload)
 
                 print(result['result'], end='')
                 if result['result'] == 'F':
                     key = '{}::{}[{}]'.format(test_module, test_method_name, parametrize_counter)
                     collected_errors[key] = result
+
+        # Unload modules loaded by the test
+        modules_loaded_by_test = [m for m in sys.modules if m not in loaded_modules]
+        for module_to_unload in modules_loaded_by_test:
+            sys.modules.pop(module_to_unload)
 
         print()
 


### PR DESCRIPTION
Patch would fail if the type's module has been unloaded prior to the test method running. In addition, patched attributes would persist between test methods.

1. Moved unloading of test loaded modules to after each module instead of each test method.
2. Patch import is done using `__import__` instead of `importlib` to avoid importing the names to the current scope.
3. Stopping patcher after each test method to restore patched attributes.
